### PR TITLE
In prometheus 2.0 this is a string, not a uint64

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func CreateFunctionNotifyFunction(bot *irc.Connection) http.HandlerFunc {
 
 		type Notification struct {
 			Version           string                 `json:"version"`
-			GroupKey          uint64                 `json:"groupKey"`
+			GroupKey          string                 `json:"groupKey"`
 			Status            string                 `json:"status"`
 			Receiver          string                 `json:"receiver"`
 			GroupLables       map[string]interface{} `json:"groupLabels"`


### PR DESCRIPTION
As the topic says, the irc webhook fails silently with:

`go-prom-irc[1273]: 2017/12/10 21:21:23 json: cannot unmarshal string into Go struct field Notification.groupKey of type uint64`

after modifying the GroupKey attribute to represent a string, the tool works again with prometheus 2.0

I just wanted to contribute this, as it might be of help.